### PR TITLE
Add LIFO executor to concurrencylimit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ## 0.x.x / 2018-x-xx
 
+* Add LIFO executor to concurrencylimit.
 * Add AIMD limiter to concurrencylimit.
 * Add concurrencylimit Runner for adaptive runners.
 

--- a/concurrencylimit/execute/executor_test.go
+++ b/concurrencylimit/execute/executor_test.go
@@ -1,0 +1,70 @@
+package execute_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/slok/goresilience/concurrencylimit/execute"
+)
+
+var benchf = func() error {
+	c := 1
+	for i := 1; i <= 5; i++ {
+		c = c * i
+	}
+	return nil
+}
+
+func BenchmarkExecutors(b *testing.B) {
+	b.StopTimer()
+
+	benchs := []struct {
+		name        string
+		getExecutor func(stopC chan struct{}) execute.Executor
+	}{
+		{
+			name: "Benchmark with FIFO (10 workers).",
+			getExecutor: func(_ chan struct{}) execute.Executor {
+				e := execute.NewFIFO(execute.FIFOConfig{})
+				e.SetWorkerQuantity(10)
+				return e
+			},
+		},
+		{
+			name: "Benchmark with LIFO (10 workers).",
+			getExecutor: func(stopC chan struct{}) execute.Executor {
+				e := execute.NewLIFO(execute.LIFOConfig{
+					StopChannel: stopC,
+				})
+				e.SetWorkerQuantity(10)
+				return e
+			},
+		},
+	}
+
+	for _, bench := range benchs {
+		b.Run(bench.name, func(b *testing.B) {
+			// Prepare.
+			stopC := make(chan struct{})
+			defer close(stopC)
+			exec := bench.getExecutor(stopC)
+
+			// Make the executions.
+			for n := 0; n < b.N; n++ {
+				b.StartTimer()
+
+				var wg sync.WaitGroup
+				wg.Add(50)
+				for i := 0; i < 50; i++ {
+					go func() {
+						defer wg.Done()
+						exec.Execute(benchf)
+					}()
+				}
+				wg.Wait()
+
+				b.StopTimer()
+			}
+		})
+	}
+}

--- a/concurrencylimit/execute/fifo_test.go
+++ b/concurrencylimit/execute/fifo_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var fOK = func() error { return nil }
-var fSleep10ms = func() error {
-	time.Sleep(10 * time.Millisecond)
-	return nil
-}
-
 func TestExecuteFIFO(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -26,7 +20,7 @@ func TestExecuteFIFO(t *testing.T) {
 		{
 			name:          "A FIFO executor with a not aggresive timeout and sufficent workers should execute all.",
 			cfg:           execute.FIFOConfig{},
-			f:             fOK,
+			f:             func() error { return nil },
 			numberCalls:   50,
 			numberWorkers: 100,
 			expOK:         50,
@@ -36,7 +30,10 @@ func TestExecuteFIFO(t *testing.T) {
 			cfg: execute.FIFOConfig{
 				MaxWaitTime: 10 * time.Nanosecond,
 			},
-			f:             fSleep10ms,
+			f: func() error {
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			},
 			numberCalls:   50,
 			numberWorkers: 25,
 			expOK:         25,

--- a/concurrencylimit/execute/lifo.go
+++ b/concurrencylimit/execute/lifo.go
@@ -1,0 +1,105 @@
+package execute
+
+import (
+	"sync"
+	"time"
+
+	"github.com/slok/goresilience/errors"
+)
+
+// LIFOConfig is the configuration for the LIFO executor.
+type LIFOConfig struct {
+	// MaxWaitTime is the max time a limiter will wait to execute before
+	// being dropped it's execution and be rejected.
+	MaxWaitTime time.Duration
+
+	// The fifo queue uses a goroutine in background to execute the queue
+	// jobs, in case it want's to be stopped a channel could be used to
+	// stop the execution.
+	StopChannel chan struct{}
+}
+
+func (c *LIFOConfig) defaults() {
+	if c.MaxWaitTime == 0 {
+		c.MaxWaitTime = 1 * time.Second
+	}
+
+	if c.StopChannel == nil {
+		c.StopChannel = make(chan struct{})
+	}
+}
+
+type lifo struct {
+	cfg   LIFOConfig
+	mu    sync.Mutex
+	queue *queue
+	workerPool
+}
+
+// NewLIFO implements a LIFO priority executor.
+func NewLIFO(cfg LIFOConfig) Executor {
+	cfg.defaults()
+
+	l := &lifo{
+		cfg:        cfg,
+		queue:      newQueue(cfg.StopChannel, enqueueAtEndPolicy, lifoDequeuePolicy),
+		workerPool: newWorkerPool(),
+	}
+	go l.fromQueueToWorkerPool()
+
+	return l
+}
+
+func (l *lifo) Execute(f func() error) error {
+	start := time.Now()
+	res := make(chan error)
+	job := func() {
+		// Maybe in the time of execution we have been waiting too much,
+		// in that case don't execute and return error.
+		if time.Since(start) > l.cfg.MaxWaitTime {
+			res <- errors.ErrRejectedExecution
+			return
+		}
+
+		res <- f()
+	}
+
+	// Send to a queue.
+	l.queue.In <- job
+
+	return <-res
+}
+
+// fromQueueToWorkerPool will get from the queue in a loop the jobs to be
+// executed by the worker pool.
+func (l *lifo) fromQueueToWorkerPool() {
+	for {
+		select {
+		case <-l.cfg.StopChannel:
+			return
+		case job := <-l.queue.Out:
+			// Send to execution worker.
+			l.workerPool.jobQueue <- job
+		}
+	}
+}
+
+// enqueueAtEndPolicy enqueues at the end of the queue.
+var enqueueAtEndPolicy = func(job func(), jobqueue []func()) []func() {
+	return append(jobqueue, job)
+}
+
+// lifoDequeuePolicy implements the policy for a LIFO priority, it will
+// dequeue de latest job queue.
+var lifoDequeuePolicy = func(queue []func()) (job func(), afterQueue []func()) {
+	switch len(queue) {
+	case 0:
+		return nil, []func(){}
+	case 1:
+		return queue[0], []func(){}
+	default:
+		// LIFO order, get the last one on the queued.
+		length := len(queue)
+		return queue[length-1], queue[:length-1]
+	}
+}

--- a/concurrencylimit/execute/lifo_test.go
+++ b/concurrencylimit/execute/lifo_test.go
@@ -20,7 +20,7 @@ func TestExecuteLIFO(t *testing.T) {
 		{
 			name:          "A LIFO executor with a not aggresive timeout and sufficent workers should execute all.",
 			cfg:           execute.LIFOConfig{},
-			f:             fOK,
+			f:             func() error { return nil },
 			numberCalls:   50,
 			numberWorkers: 100,
 			expOK:         50,
@@ -28,9 +28,12 @@ func TestExecuteLIFO(t *testing.T) {
 		{
 			name: "A simple executor with a an aggresive timeout and not sufficent workers should fail fast.",
 			cfg: execute.LIFOConfig{
-				MaxWaitTime: 5000 * time.Nanosecond,
+				MaxWaitTime: 5 * time.Millisecond,
 			},
-			f:             fSleep10ms,
+			f: func() error {
+				time.Sleep(30 * time.Millisecond)
+				return nil
+			},
 			numberCalls:   50,
 			numberWorkers: 25,
 			expOK:         25,

--- a/concurrencylimit/execute/lifo_test.go
+++ b/concurrencylimit/execute/lifo_test.go
@@ -1,0 +1,121 @@
+package execute_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/slok/goresilience/concurrencylimit/execute"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecuteLIFO(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           execute.LIFOConfig
+		f             func() error
+		numberCalls   int
+		numberWorkers int
+		expOK         int
+	}{
+		{
+			name:          "A LIFO executor with a not aggresive timeout and sufficent workers should execute all.",
+			cfg:           execute.LIFOConfig{},
+			f:             fOK,
+			numberCalls:   50,
+			numberWorkers: 100,
+			expOK:         50,
+		},
+		{
+			name: "A simple executor with a an aggresive timeout and not sufficent workers should fail fast.",
+			cfg: execute.LIFOConfig{
+				MaxWaitTime: 5000 * time.Nanosecond,
+			},
+			f:             fSleep10ms,
+			numberCalls:   50,
+			numberWorkers: 25,
+			expOK:         25,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			exec := execute.NewLIFO(test.cfg)
+
+			// Set the number of workers.
+			exec.SetWorkerQuantity(test.numberWorkers)
+
+			// Execute multiple concurrent cals.
+			results := make(chan error)
+			for i := 0; i < test.numberCalls; i++ {
+				go func() {
+					results <- exec.Execute(test.f)
+				}()
+			}
+
+			// Grab the results.
+			gotOK := 0
+			for i := 0; i < test.numberCalls; i++ {
+				if res := <-results; res == nil {
+					gotOK++
+				}
+			}
+
+			// Check the results.
+			assert.Equal(test.expOK, gotOK)
+		})
+	}
+}
+
+func TestExecuteLIFOOrder(t *testing.T) {
+	tests := []struct {
+		name        string
+		numberCalls int
+		expResult   []int
+	}{
+		{
+			name:        "In a LIFO queue the queued objects should execute in a first-in-first-out priority.",
+			numberCalls: 12,
+			// Due how the wait signals from the queue is implemented the first two
+			// elements in the queue will be get before the others.
+			expResult: []int{0, 1, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			exec := execute.NewLIFO(execute.LIFOConfig{
+				MaxWaitTime: 500 * time.Second, // Long enough so doesn't timeout anything.
+			})
+
+			// Execute multiple concurrent cals.
+			results := make(chan int)
+			for i := 0; i < test.numberCalls; i++ {
+				time.Sleep(1 * time.Millisecond)
+				i := i
+				go func() {
+					exec.Execute(func() error {
+						results <- i
+						return nil
+					})
+				}()
+			}
+			time.Sleep(10 * time.Millisecond)
+
+			// Set the number of workers. This will start draining the queue.
+			exec.SetWorkerQuantity(1)
+
+			// Grab the results.
+			gotResult := []int{}
+			for i := 0; i < test.numberCalls; i++ {
+				gotResult = append(gotResult, <-results)
+			}
+
+			// Check the results.
+			assert.Equal(test.expResult, gotResult)
+		})
+	}
+}

--- a/concurrencylimit/execute/queue.go
+++ b/concurrencylimit/execute/queue.go
@@ -1,0 +1,115 @@
+package execute
+
+import (
+	"sync"
+)
+
+// dequeuePolicy will receive a queue of jobs and return a job and the result of the
+// queue after dequeing the job.
+type dequeuePolicy func(beforeJobQ []func()) (job func(), afterJobQ []func())
+
+// enqueuePolicy will receive a queue of jobs and a job and will queue the job.
+type enqueuePolicy func(job func(), beforeJobQ []func()) (afterJobQ []func())
+
+// queue is a queue that knows how to queue and dequeue objects using different kind of policies.
+type queue struct {
+	// In is the channel we will add to the queue.
+	In chan func()
+	// Out is the channel we will remove from the queue.
+	Out           chan func()
+	mu            sync.Mutex
+	jobs          []func()
+	enqueuePolicy enqueuePolicy
+	dequeuePolicy dequeuePolicy
+	stopC         chan struct{}
+	// wakeupDequeuerC will be use to  wake up the dequeuer that has been sleeping due to no jobs on the queue.
+	wakeUpDequeuerC chan struct{}
+}
+
+func newQueue(stopC chan struct{}, enqueuePolicy enqueuePolicy, dequeuePolicy dequeuePolicy) *queue {
+	q := &queue{
+		In:            make(chan func()),
+		Out:           make(chan func()),
+		enqueuePolicy: enqueuePolicy,
+		dequeuePolicy: dequeuePolicy,
+		stopC:         stopC,
+		// wakeUpDequeuerC will be used to wake up the dequeuer when the queue goes empty so we don't need
+		// to poll the queue every T interval (is an optimization), this way the enqueuer will notify through
+		// this channel the dequeuer that elements have been added and needs to wake up to dequeue those
+		// new elements.
+		//
+		// We use a buffered channel so the queue doesn't get blocked/stuck forever, because it could happen that
+		// the signal is sent when the dequeuer isn't listening and when it starts waiting, the signal has
+		// been ignored. This is because the enqueuer doesn't get blocked when sending the signals to the dequeuer
+		// through this channel, it notifies only if the dequeuer is listening. Using a buffered channel of 1 is enough
+		// to tell the dequeuer that at least one job has been enqueued and it can wake up although it wasn't listening
+		// at the time of notifying in the enqueue moment.
+		// A drawback is that could happen that the dequeuer gets the buffered signal of an old and already queued element
+		// and in the moment of waking up, the queue is empty, so that's why we need to check again if the queue is empty
+		// just after waiking up the dequeuer.
+		wakeUpDequeuerC: make(chan struct{}, 1),
+	}
+
+	// Start the background jobs that accept/return In/Out jobs.
+	go q.dequeuer()
+	go q.enqueuer()
+
+	return q
+}
+
+func (q *queue) enqueuer() {
+	for {
+		select {
+		case <-q.stopC:
+			return
+		case job := <-q.In:
+			q.mu.Lock()
+			q.jobs = q.enqueuePolicy(job, q.jobs)
+
+			// If the dequeuer is sleeping it will get the wake up signal, if not
+			// the channel will not be being read and the default case will be selected.
+			select {
+			case q.wakeUpDequeuerC <- struct{}{}:
+			default:
+			}
+			q.mu.Unlock()
+		}
+	}
+}
+
+var x = 0
+
+func (q *queue) dequeuer() {
+	for {
+		select {
+		case <-q.stopC:
+			return
+		default:
+		}
+		// If there are no jobs, instead of polling, sleep the dequeuer until
+		// a job enters the queue, our enqueuer will try to wake up us when any
+		// job is queued.
+		if q.queueIsEmpty() {
+			<-q.wakeUpDequeuerC
+
+			// Check again after unblocking because could be the buffered channel signal
+			// of a queue object that we had already processed.
+			if q.queueIsEmpty() {
+				continue
+			}
+		}
+
+		var job func()
+		q.mu.Lock()
+		job, q.jobs = q.dequeuePolicy(q.jobs)
+		q.mu.Unlock()
+		// Send the correct job with the channel.
+		q.Out <- job
+	}
+}
+
+func (q *queue) queueIsEmpty() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.jobs) < 1
+}


### PR DESCRIPTION
This PR adds LIFO execution policy to the concurrencylimit executor. With this executor we could create a concurrencylimit that will execute the enqueued runner funcs in a last-in-first-out priority.

Also adds a private policy based queue that can be customized with enqueue and dequeue policies (is the one used for the LIFO executor).
