### PR TITLE
Add Adaptive LIFO + CoDel executor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ## 0.x.x / 2018-x-xx
 
+* Add Adaptive LIFO with CoDel executor to concurrencylimit.
 * Add LIFO executor to concurrencylimit.
 * Add AIMD limiter to concurrencylimit.
 * Add concurrencylimit Runner for adaptive runners.

--- a/Readme.md
+++ b/Readme.md
@@ -173,11 +173,13 @@ Check [example][concurrencylimit-example].
 #### Executors
 
 - `FIFO`: This executor is the default one it will execute the queue jobs in a first-in-first-out order and also has a queue wait timeout.
+- `LIFO`: This executor will execute the queue jobs in a last-in-first-out order and also has a queue wait timeout.
+- `AdaptiveLIFOCodel`: Implementation of Facebook's [CoDel+adaptive LIFO][fb-codel] algorithm. This executor is used with `Static` limiter.
 
 #### Limiter
 
 - `Static`: This limiter will set a constant limit that will not change.
-- `AIMD`: This limiter is based on [AIMD] TCP congestion algorithm. It increases the limit at a constant rate and when congestion occurs (by timeout or result failure) it will decrese by a configured factor
+- `AIMD`: This limiter is based on [AIMD] TCP congestion algorithm. It increases the limit at a constant rate and when congestion occurs (by timeout or result failure) it will decrease by a configured factor
 
 #### Result policy
 
@@ -293,3 +295,4 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
 [aimd]: https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
 [concurrency-limit]: https://github.com/Netflix/concurrency-limits
 [aimd]: https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
+[fb-code]: https://queue.acm.org/detail.cfm?id=2839461

--- a/bulkhead/bulkhead.go
+++ b/bulkhead/bulkhead.go
@@ -40,12 +40,12 @@ type bulkhead struct {
 	jobC   chan func() // jobC is the channel used to send job to the worker pool.
 }
 
-// New returns a new buklhead runner.
+// New returns a new bulkhead runner.
 // Bulkhead will limit the execution of execution blocks based on
 // a configuration. The bulkhead implementation will be made
 // using a worker of pools, the workers will pick these execution blocks
 // when they are free, they will execute the logic and pick another block
-// the exeuction block will wait to be picked by the workers and if they
+// the execution block will wait to be picked by the workers and if they
 // have a max wait time, if that time is passed they will be dropped
 // from the execution queue.
 func New(cfg Config) goresilience.Runner {

--- a/concurrencylimit/execute/codel.go
+++ b/concurrencylimit/execute/codel.go
@@ -1,0 +1,134 @@
+package execute
+
+import (
+	"time"
+
+	"github.com/slok/goresilience/errors"
+)
+
+// AdaptiveLIFOCodelConfig is the configuration for the AdaptiveLIFOCodel executor.
+type AdaptiveLIFOCodelConfig struct {
+	// CodelTarget is the duration the execution funcs can be on the queue before being
+	// rejected when the controlled delay congestion has been activated (a.k.a bufferbloat detected).
+	CodelTarget time.Duration
+	// CodelInterval is the default max time the funcs can be on the queue before being rejected.
+	CodelInterval time.Duration
+	// The queue uses a goroutine in background to execute the queue
+	// jobs, in case it want's to be stopped a channel could be used to
+	// stop the execution.
+	StopChannel chan struct{}
+}
+
+func (c *AdaptiveLIFOCodelConfig) defaults() {
+	if c.StopChannel == nil {
+		c.StopChannel = make(chan struct{})
+	}
+
+	if c.CodelTarget == 0 {
+		c.CodelTarget = 5 * time.Millisecond
+	}
+
+	if c.CodelInterval == 0 {
+		c.CodelInterval = 100 * time.Millisecond
+	}
+}
+
+type adaptiveLIFOCodel struct {
+	cfg   AdaptiveLIFOCodelConfig
+	queue *queue
+	workerPool
+}
+
+// NewAdaptiveLIFOCodel is an executor based on Codel algorithm (Controlled delay) for the execution,
+// more info here https://queue.acm.org/detail.cfm?id=2209336, and adaptive LIFO for the queue
+// priority.
+//
+// Codel implementation it's based on Facebook's Codel usage for resiliency.
+// More information can be found here: https://queue.acm.org/detail.cfm?id=2839461
+//
+// At first the queue priority will be FIFO, but when we detect bufferbloat it will change queue
+// execution priority to LIFO.
+// On the other hand the execution timeout will change based on the last time the queue was empty
+// this will give us the ability to set a lesser timeout on the queued executions when the queue
+// starts to grow.
+func NewAdaptiveLIFOCodel(cfg AdaptiveLIFOCodelConfig) Executor {
+
+	cfg.defaults()
+
+	a := &adaptiveLIFOCodel{
+		cfg:        cfg,
+		queue:      newQueue(cfg.StopChannel, enqueueAtEndPolicy, fifoDequeuePolicy),
+		workerPool: newWorkerPool(),
+	}
+	go a.fromQueueToWorkerPool()
+
+	return a
+}
+
+func (a *adaptiveLIFOCodel) Execute(f func() error) error {
+	var timeout time.Duration
+	// If we are congested then we need to change de queuing policy to LIFO
+	// and set the congestion timeout to the aggressive CoDel timeout.
+	if a.queueCongested() {
+		a.queue.SetDequeuePolicy(lifoDequeuePolicy)
+		timeout = a.cfg.CodelTarget
+	} else {
+		// No congestion means fifo and regular timeout.
+		a.queue.SetDequeuePolicy(fifoDequeuePolicy)
+		timeout = a.cfg.CodelInterval
+	}
+
+	// This channel will receive a signal if the job is cancelled.
+	cancelJob := make(chan struct{})
+
+	// Create a job and listen if the job has been cancelled before
+	// executing something that will not be used due to an upper layer
+	// already cancelled (this layer).
+	res := make(chan error)
+	job := func() {
+		select {
+		case <-cancelJob:
+			return
+		default:
+		}
+
+		// Don't wait if the channel has been cancelled due to a timeout.
+		select {
+		case res <- f():
+		default:
+		}
+	}
+
+	// Enqueue the job.
+	go func() {
+		a.queue.InChannel() <- job
+	}()
+
+	// Wait until executed or timeout.
+	select {
+	case <-time.After(timeout):
+		close(cancelJob)
+		return errors.ErrRejectedExecution
+	case result := <-res:
+		return result
+	}
+}
+
+// fromQueueToWorkerPool will get from the queue in a loop the jobs to be
+// executed by the worker pool.
+func (a *adaptiveLIFOCodel) fromQueueToWorkerPool() {
+	for {
+		select {
+		case <-a.cfg.StopChannel:
+			return
+		case job := <-a.queue.OutChannel():
+			// Send to execution worker.
+			a.workerPool.jobQueue <- job
+		}
+	}
+}
+
+// queueCongested will calculate if the queue is congested based on CoDel algorithm.
+func (a *adaptiveLIFOCodel) queueCongested() bool {
+	return time.Since(a.queue.LastEmptyTime()) > a.cfg.CodelInterval
+}

--- a/concurrencylimit/execute/codel_test.go
+++ b/concurrencylimit/execute/codel_test.go
@@ -51,21 +51,21 @@ func TestCodel(t *testing.T) {
 		{
 			name: "An execution that detects congestion using CoDel should activate target timeout and use LIFO priority for the queue.",
 			cfg: execute.AdaptiveLIFOCodelConfig{
-				CodelTarget:   2 * time.Millisecond,
-				CodelInterval: 5 * time.Millisecond,
+				CodelTargetDelay: 10 * time.Millisecond,
+				CodelInterval:    50 * time.Millisecond,
 			},
 			exec: func(exec execute.Executor) []string {
 				// This test will probe the CoDel algorithm works. With one worker everything will
 				// be easier.
-				// 1 - Enqueue 10 jobs with a execution delay of 5m (CoDel interval 5ms).
+				// 1 - Enqueue 10 jobs with a execution delay of 100ms (CoDel interval 50ms).
 				// 2 - The first jobs will be executed in order(0, 1...)
 				// 3 - After the first delayed work, CoDel triggers congestion and starts executing in LIFO (9, 8...)
-				// 4 - The LIFO execution jobs (9, 8, 7...) have a lesser timeout than the FIFO ones (0, 1, 2)
-				// 5 - The last jobs of the queue (they have been enqueued with CoDel active) will be timeout.
-				// 6 - give time so CoDel empties the queue.
+				// 4 - The LIFO execution jobs (9, 8, 7...) have a lesser timeout than the FIFO ones (0, 1, 2), 10ms
+				// 5 - The last jobs of the queue (they have been enqueued with CoDel active) will be timeout (10ms).
+				// 6 - Give time so CoDel empties the queue (wait 200ms).
 				// 7 - Add another 10 items with a low delay of execution.
 				// 8 - The execution is FIFO due to not be in congestion after emptying the queue and this new jobs
-				//	   not triggering congestion neither.
+				//	   not triggering congestion neither (a.k.a self healed by CoDel + adaptive LIFO).
 
 				exec.SetWorkerQuantity(1)
 
@@ -82,11 +82,11 @@ func TestCodel(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					// Sleep so the funcs enter in order and are executed by the
 					// unique worker.
-					time.Sleep(1 * time.Millisecond)
+					time.Sleep(10 * time.Millisecond)
 					i := i
 					go func() {
 						exec.Execute(func() error {
-							time.Sleep(5 * time.Millisecond)
+							time.Sleep(100 * time.Millisecond)
 							resultC <- fmt.Sprintf("id-%d", i)
 							return nil
 						})
@@ -94,7 +94,7 @@ func TestCodel(t *testing.T) {
 				}
 
 				// Wait to empty the queue.
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(200 * time.Millisecond)
 
 				for i := 10; i < 15; i++ {
 					// Sleep so the funcs enter in order and are executed by the
@@ -111,12 +111,12 @@ func TestCodel(t *testing.T) {
 				}
 
 				// Wait for final results grab.
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(200 * time.Millisecond)
 
 				return results
 			},
 			expResults: []string{
-				"id-0", "id-1", // congestion activated.
+				"id-0", // congestion activated.
 				"id-9", // enqueued in congestion, dequeued in FIFO.
 				// Timeout all the ones when enqueued with congestion (2, 3, 4, 5, 6, 7, 8)
 				"id-10", "id-11", "id-12", "id-13", "id-14", // Executed in LIFO (without congestion).

--- a/concurrencylimit/execute/codel_test.go
+++ b/concurrencylimit/execute/codel_test.go
@@ -1,0 +1,141 @@
+package execute_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/slok/goresilience/concurrencylimit/execute"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCodel(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        execute.AdaptiveLIFOCodelConfig
+		exec       func(exec execute.Executor) (results []string)
+		expResults []string
+	}{
+		{
+			name: "A regular execution using CoDel should not activate target timeout and use FIFO priority for the queue.",
+			cfg:  execute.AdaptiveLIFOCodelConfig{},
+			exec: func(exec execute.Executor) []string {
+				exec.SetWorkerQuantity(1)
+
+				resultC := make(chan string)
+				for i := 0; i < 10; i++ {
+					// Sleep so the funcs enter in order and are executed by the
+					// unique worker.
+					time.Sleep(2 * time.Millisecond)
+					i := i
+					go func() {
+						exec.Execute(func() error {
+							time.Sleep(1 * time.Millisecond)
+							resultC <- fmt.Sprintf("id-%d", i)
+							return nil
+						})
+					}()
+				}
+
+				// Grab results.
+				results := []string{}
+				for i := 0; i < 10; i++ {
+					res := <-resultC
+					results = append(results, res)
+				}
+
+				return results
+			},
+			expResults: []string{"id-0", "id-1", "id-2", "id-3", "id-4", "id-5", "id-6", "id-7", "id-8", "id-9"},
+		},
+		{
+			name: "An execution that detects congestion using CoDel should activate target timeout and use LIFO priority for the queue.",
+			cfg: execute.AdaptiveLIFOCodelConfig{
+				CodelTarget:   2 * time.Millisecond,
+				CodelInterval: 5 * time.Millisecond,
+			},
+			exec: func(exec execute.Executor) []string {
+				// This test will probe the CoDel algorithm works. With one worker everything will
+				// be easier.
+				// 1 - Enqueue 10 jobs with a execution delay of 5m (CoDel interval 5ms).
+				// 2 - The first jobs will be executed in order(0, 1...)
+				// 3 - After the first delayed work, CoDel triggers congestion and starts executing in LIFO (9, 8...)
+				// 4 - The LIFO execution jobs (9, 8, 7...) have a lesser timeout than the FIFO ones (0, 1, 2)
+				// 5 - The last jobs of the queue (they have been enqueued with CoDel active) will be timeout.
+				// 6 - give time so CoDel empties the queue.
+				// 7 - Add another 10 items with a low delay of execution.
+				// 8 - The execution is FIFO due to not be in congestion after emptying the queue and this new jobs
+				//	   not triggering congestion neither.
+
+				exec.SetWorkerQuantity(1)
+
+				resultC := make(chan string)
+
+				// Execute the result grab.
+				results := []string{}
+				go func() {
+					for res := range resultC {
+						results = append(results, res)
+					}
+				}()
+
+				for i := 0; i < 10; i++ {
+					// Sleep so the funcs enter in order and are executed by the
+					// unique worker.
+					time.Sleep(1 * time.Millisecond)
+					i := i
+					go func() {
+						exec.Execute(func() error {
+							time.Sleep(5 * time.Millisecond)
+							resultC <- fmt.Sprintf("id-%d", i)
+							return nil
+						})
+					}()
+				}
+
+				// Wait to empty the queue.
+				time.Sleep(100 * time.Millisecond)
+
+				for i := 10; i < 15; i++ {
+					// Sleep so the funcs enter in order and are executed by the
+					// unique worker.
+					time.Sleep(1 * time.Millisecond)
+					i := i
+					go func() {
+						exec.Execute(func() error {
+							time.Sleep(1 * time.Millisecond)
+							resultC <- fmt.Sprintf("id-%d", i)
+							return nil
+						})
+					}()
+				}
+
+				// Wait for final results grab.
+				time.Sleep(100 * time.Millisecond)
+
+				return results
+			},
+			expResults: []string{
+				"id-0", "id-1", // congestion activated.
+				"id-9", // enqueued in congestion, dequeued in FIFO.
+				// Timeout all the ones when enqueued with congestion (2, 3, 4, 5, 6, 7, 8)
+				"id-10", "id-11", "id-12", "id-13", "id-14", // Executed in LIFO (without congestion).
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Prepare executor.
+			codel := execute.NewAdaptiveLIFOCodel(test.cfg)
+
+			// Execute.
+			gotResults := test.exec(codel)
+
+			// Check.
+			assert.Equal(test.expResults, gotResults)
+		})
+	}
+}

--- a/concurrencylimit/execute/executor_test.go
+++ b/concurrencylimit/execute/executor_test.go
@@ -40,6 +40,16 @@ func BenchmarkExecutors(b *testing.B) {
 				return e
 			},
 		},
+		{
+			name: "Benchmark with adaptive LIFO + CoDel (10 workers).",
+			getExecutor: func(stopC chan struct{}) execute.Executor {
+				e := execute.NewAdaptiveLIFOCodel(execute.AdaptiveLIFOCodelConfig{
+					StopChannel: stopC,
+				})
+				e.SetWorkerQuantity(10)
+				return e
+			},
+		},
 	}
 
 	for _, bench := range benchs {

--- a/concurrencylimit/execute/fifo.go
+++ b/concurrencylimit/execute/fifo.go
@@ -23,7 +23,7 @@ func (c *FIFOConfig) defaults() {
 // and queued with FIFO priority until one worker is free or the timeout is reached, in this last
 // case the execution will be treat as rejected.
 //
-// The FIFO kind queue is based on internal implmentation of Go channels that makes blocked sends to a
+// The FIFO kind queue is based on internal implementation of Go channels that makes blocked sends to a
 // channel execute in a first-in-first-out priority.
 func NewFIFO(cfg FIFOConfig) Executor {
 	cfg.defaults()

--- a/concurrencylimit/execute/fifo_test.go
+++ b/concurrencylimit/execute/fifo_test.go
@@ -95,7 +95,7 @@ func TestExecuteFIFOOrder(t *testing.T) {
 			// Set the number of workers.
 			exec.SetWorkerQuantity(1)
 
-			// Execute multiple concurrent cals.
+			// Execute multiple concurrent calls.
 			results := make(chan int)
 			for i := 0; i < test.numberCalls; i++ {
 				// sleep on each iteration to guarantee that the goroutines are executed

--- a/concurrencylimit/execute/lifo_test.go
+++ b/concurrencylimit/execute/lifo_test.go
@@ -49,7 +49,7 @@ func TestExecuteLIFO(t *testing.T) {
 			// Set the number of workers.
 			exec.SetWorkerQuantity(test.numberWorkers)
 
-			// Execute multiple concurrent cals.
+			// Execute multiple concurrent calls.
 			results := make(chan error)
 			for i := 0; i < test.numberCalls; i++ {
 				go func() {

--- a/concurrencylimit/execute/lifo_test.go
+++ b/concurrencylimit/execute/lifo_test.go
@@ -94,7 +94,7 @@ func TestExecuteLIFOOrder(t *testing.T) {
 				MaxWaitTime: 500 * time.Second, // Long enough so doesn't timeout anything.
 			})
 
-			// Execute multiple concurrent cals.
+			// Execute multiple concurrent calls.
 			results := make(chan int)
 			for i := 0; i < test.numberCalls; i++ {
 				time.Sleep(1 * time.Millisecond)

--- a/concurrencylimit/execute/queue.go
+++ b/concurrencylimit/execute/queue.go
@@ -2,6 +2,7 @@ package execute
 
 import (
 	"sync"
+	"time"
 )
 
 // dequeuePolicy will receive a queue of jobs and return a job and the result of the
@@ -12,27 +13,29 @@ type dequeuePolicy func(beforeJobQ []func()) (job func(), afterJobQ []func())
 type enqueuePolicy func(job func(), beforeJobQ []func()) (afterJobQ []func())
 
 // queue is a queue that knows how to queue and dequeue objects using different kind of policies.
+// these policies can be changed with the queue is running.
 type queue struct {
-	// In is the channel we will add to the queue.
-	In chan func()
-	// Out is the channel we will remove from the queue.
-	Out           chan func()
+	in            chan func()
+	out           chan func()
 	mu            sync.Mutex
+	policyMu      sync.RWMutex
 	jobs          []func()
 	enqueuePolicy enqueuePolicy
 	dequeuePolicy dequeuePolicy
 	stopC         chan struct{}
+	lastEmptyTime time.Time
 	// wakeupDequeuerC will be use to  wake up the dequeuer that has been sleeping due to no jobs on the queue.
 	wakeUpDequeuerC chan struct{}
 }
 
 func newQueue(stopC chan struct{}, enqueuePolicy enqueuePolicy, dequeuePolicy dequeuePolicy) *queue {
 	q := &queue{
-		In:            make(chan func()),
-		Out:           make(chan func()),
+		in:            make(chan func()),
+		out:           make(chan func()),
 		enqueuePolicy: enqueuePolicy,
 		dequeuePolicy: dequeuePolicy,
 		stopC:         stopC,
+		lastEmptyTime: time.Now(),
 		// wakeUpDequeuerC will be used to wake up the dequeuer when the queue goes empty so we don't need
 		// to poll the queue every T interval (is an optimization), this way the enqueuer will notify through
 		// this channel the dequeuer that elements have been added and needs to wake up to dequeue those
@@ -57,15 +60,47 @@ func newQueue(stopC chan struct{}, enqueuePolicy enqueuePolicy, dequeuePolicy de
 	return q
 }
 
+func (q *queue) LastEmptyTime() time.Time {
+	// No need a mutex, assume small differences that will end
+	// in the same state in favor of better performance.
+	if q.queueIsEmpty() {
+		q.lastEmptyTime = time.Now()
+	}
+	return q.lastEmptyTime
+}
+
+// InChannel returns a channel where the queue will receive the jobs.
+func (q *queue) InChannel() chan<- func() {
+	return q.in
+}
+
+// OutChannel returns a channel where the jobs of the queue can be dequeued.
+func (q *queue) OutChannel() <-chan func() {
+	return q.out
+}
+
+func (q *queue) SetEnqueuePolicy(p enqueuePolicy) {
+	q.policyMu.Lock()
+	defer q.policyMu.Unlock()
+	q.enqueuePolicy = p
+}
+
+func (q *queue) SetDequeuePolicy(p dequeuePolicy) {
+	q.policyMu.Lock()
+	defer q.policyMu.Unlock()
+	q.dequeuePolicy = p
+}
+
 func (q *queue) enqueuer() {
 	for {
 		select {
 		case <-q.stopC:
 			return
-		case job := <-q.In:
+		case job := <-q.in:
 			q.mu.Lock()
+			q.policyMu.RLock()
 			q.jobs = q.enqueuePolicy(job, q.jobs)
-
+			q.policyMu.RUnlock()
 			// If the dequeuer is sleeping it will get the wake up signal, if not
 			// the channel will not be being read and the default case will be selected.
 			select {
@@ -98,13 +133,14 @@ func (q *queue) dequeuer() {
 				continue
 			}
 		}
-
 		var job func()
 		q.mu.Lock()
+		q.policyMu.RLock()
 		job, q.jobs = q.dequeuePolicy(q.jobs)
+		q.policyMu.RUnlock()
 		q.mu.Unlock()
 		// Send the correct job with the channel.
-		q.Out <- job
+		q.out <- job
 	}
 }
 
@@ -112,4 +148,36 @@ func (q *queue) queueIsEmpty() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return len(q.jobs) < 1
+}
+
+// Queue Policies.
+// enqueueAtEndPolicy enqueues at the end of the queue.
+var enqueueAtEndPolicy = func(job func(), jobqueue []func()) []func() {
+	return append(jobqueue, job)
+}
+
+// lifoDequeuePolicy implements the policy for a LIFO priority, it will
+// dequeue de latest job queue.
+var lifoDequeuePolicy = func(queue []func()) (job func(), afterQueue []func()) {
+	switch len(queue) {
+	case 0:
+		return nil, []func(){}
+	case 1:
+		return queue[0], []func(){}
+	default:
+		// LIFO order, get the last one on the queued.
+		length := len(queue)
+		return queue[length-1], queue[:length-1]
+	}
+}
+
+// fifoDequeuePolicy implements the policy for a FIFO priority, it will
+// dequeue de first job in the queue.
+var fifoDequeuePolicy = func(queue []func()) (job func(), afterQueue []func()) {
+	switch len(queue) {
+	case 0:
+		return nil, []func(){}
+	default:
+		return queue[0], queue[1:]
+	}
 }


### PR DESCRIPTION
This PR adds the executor that implements Facebook CoDel based  + adaptive LIFO algorithm
- [CoDel original algorithm](https://queue.acm.org/detail.cfm?id=2209336).
- [Facebook's CoDel](https://queue.acm.org/detail.cfm?id=2839461).

The basics of the algorithm are based that when congestion is detected in the queue waiting time, the priority of dequeueing in the queue is changed from FIFO(without congestion) to LIFO(with congestion) and the new enqueued jobs will have a small timeout for the queued wait timeout.

More changes:
- The generic internal queue now can change the queue policy dynamically.
- The generic internal queue now can give the last time the queue was empty.
- Fix LIFO queue timeout (before the timeout was applied also to the execution time, not only the queued time).