### PR TITLE
Refactor concurrencylimit result policies

### DIFF
--- a/concurrencylimit/doc.go
+++ b/concurrencylimit/doc.go
@@ -4,10 +4,10 @@ package concurrencylimit
 // it tries to create a concurrency controlled execution flow using adaptive algorithms
 // from TCP congestion control algorithms.
 //
-// The implementation of concurrencylimit runner is based in 4 componentes:
+// The implementation of concurrencylimit runner is based in 4 components:
 //
 // - The Limiter algorithm: This is the algorithm used to calculate
-// 	 the limit of concunrrency. There are multiple to select based on the type
+// 	 the limit of concurrency. There are multiple to select based on the type
 // 	 of execution flow used on the Runner (client side, server side,
 //   lot's of dependencies...).
 //
@@ -20,7 +20,7 @@ package concurrencylimit
 //	 thing, fallback, return error or whatever.
 //
 // - The Runner: This is the one that implements goresilience.Runner, it's the
-//	 one that will be used directly by a goreslience library user. It glues
+//	 one that will be used directly by a goresilience library user. It glues
 //	 together the algorithm and the executor, knows how to handle the  user Func
 //   to be executed by the executor, knows how to measure the result to give it
 //   to the algorithm to create a new limit dynamically, sets those limits on the

--- a/concurrencylimit/limit/limiter.go
+++ b/concurrencylimit/limit/limiter.go
@@ -26,6 +26,6 @@ type Limiter interface {
 	// It also returns the current limit after measuring the samples.
 	MeasureSample(startTime time.Time, inflight int, result Result) int
 
-	// Gets the curent limit.
+	// Gets the current limit.
 	GetLimit() int
 }

--- a/concurrencylimit/limit/static.go
+++ b/concurrencylimit/limit/static.go
@@ -23,7 +23,7 @@ func (s *static) MeasureSample(_ time.Time, _ int, _ Result) int {
 	return s.GetLimit()
 }
 
-// GetLimit satsifies Algorithm interface.
+// GetLimit satisfies Algorithm interface.
 func (s *static) GetLimit() int {
 	return s.limit
 }

--- a/concurrencylimit/policy.go
+++ b/concurrencylimit/policy.go
@@ -1,0 +1,56 @@
+package concurrencylimit
+
+import (
+	"context"
+
+	"github.com/slok/goresilience/concurrencylimit/limit"
+	"github.com/slok/goresilience/errors"
+)
+
+// ExecutionResultPolicy is the function that will have the responsibility of
+// categorizing the result of the execution for the limiter algorithm. For example
+// depending on the type of the execution a connection error could be treated
+// like an failure in the algorithm or just ignore it.
+type ExecutionResultPolicy func(ctx context.Context, err error) limit.Result
+
+// FailureOnExternalErrorPolicy will treat as failure every error that is not
+// from concurrencylimit package (this is the error by the limiters).
+var FailureOnExternalErrorPolicy = func(_ context.Context, err error) limit.Result {
+	// Everything ok.
+	if err == nil {
+		return limit.ResultSuccess
+	}
+
+	// Our own failures should be ignored, the rest nope.
+	if err != nil && err != errors.ErrRejectedExecution {
+		return limit.ResultFailure
+	}
+
+	return limit.ResultIgnore
+}
+
+// NoFailurePolicy will treat will never return a failure, just ignore when an error
+// occurs, this can be used to adapt only on RTT/latency.
+var NoFailurePolicy = func(_ context.Context, err error) limit.Result {
+	// Everything ok.
+	if err == nil {
+		return limit.ResultSuccess
+	}
+
+	return limit.ResultIgnore
+}
+
+// FailureOnRejectedPolicy will treat as failure every time the execution has been
+// rejected with a `errors.ErrRejectedExecution` error.
+var FailureOnRejectedPolicy = func(_ context.Context, err error) limit.Result {
+	// Everything ok.
+	if err == nil {
+		return limit.ResultSuccess
+	}
+
+	if err != nil && err == errors.ErrRejectedExecution {
+		return limit.ResultFailure
+	}
+
+	return limit.ResultIgnore
+}

--- a/concurrencylimit/policy_test.go
+++ b/concurrencylimit/policy_test.go
@@ -1,0 +1,79 @@
+package concurrencylimit_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/slok/goresilience/concurrencylimit"
+	"github.com/slok/goresilience/concurrencylimit/limit"
+	goresilienceerrors "github.com/slok/goresilience/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicies(t *testing.T) {
+	tests := []struct {
+		name      string
+		policy    concurrencylimit.ExecutionResultPolicy
+		err       error
+		expResult limit.Result
+	}{
+		{
+			name:      "FailureOnExternalErrorPolicy no failure should return success",
+			policy:    concurrencylimit.FailureOnExternalErrorPolicy,
+			err:       nil,
+			expResult: limit.ResultSuccess,
+		},
+		{
+			name:      "FailureOnExternalErrorPolicy with an external failure should return a failure",
+			policy:    concurrencylimit.FailureOnExternalErrorPolicy,
+			err:       errors.New("external error"),
+			expResult: limit.ResultFailure,
+		},
+		{
+			name:      "FailureOnExternalErrorPolicy with a exec rejection failure should return ignore",
+			policy:    concurrencylimit.FailureOnExternalErrorPolicy,
+			err:       goresilienceerrors.ErrRejectedExecution,
+			expResult: limit.ResultIgnore,
+		},
+		{
+			name:      "NoFailurePolicy no failure should return success",
+			policy:    concurrencylimit.NoFailurePolicy,
+			err:       nil,
+			expResult: limit.ResultSuccess,
+		},
+		{
+			name:      "NoFailurePolicy with any failure should return ignore",
+			policy:    concurrencylimit.NoFailurePolicy,
+			err:       errors.New("external error"),
+			expResult: limit.ResultIgnore,
+		},
+		{
+			name:      "FailureOnRejectedPolicy no failure should return success",
+			policy:    concurrencylimit.FailureOnRejectedPolicy,
+			err:       nil,
+			expResult: limit.ResultSuccess,
+		},
+		{
+			name:      "FailureOnRejectedPolicy with an external failure should return ignore",
+			policy:    concurrencylimit.FailureOnRejectedPolicy,
+			err:       errors.New("external error"),
+			expResult: limit.ResultIgnore,
+		},
+		{
+			name:      "FailureOnRejectedPolicy with a exec rejection failure should return a failure",
+			policy:    concurrencylimit.FailureOnRejectedPolicy,
+			err:       goresilienceerrors.ErrRejectedExecution,
+			expResult: limit.ResultFailure,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			res := test.policy(context.TODO(), test.err)
+			assert.Equal(test.expResult, res)
+		})
+	}
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,6 @@
 package errors
 
-// Error is a goresilience error. Although sitisfies Error interface from Golang
+// Error is a goresilience error. Although satisfies Error interface from Golang
 // this gives us the ability to check if the error was triggered by a Runner or not.
 type Error string
 
@@ -12,9 +12,9 @@ var (
 	// ErrTimeout will be used when a execution timesout.
 	ErrTimeout = Error("timeout while executing")
 	// ErrContextCanceled will be used when the execution has not been executed due to the
-	// context cancelation.
+	// context cancellation.
 	ErrContextCanceled = Error("context canceled, logic not executed")
-	// ErrTimeoutWaitingForExecution will be used when a exeuction block exceeded waiting
+	// ErrTimeoutWaitingForExecution will be used when a execution block exceeded waiting
 	// to be executed, for example if a worker pool has been busy and the execution object
 	// has been waiting to much for being picked by a pool worker.
 	ErrTimeoutWaitingForExecution = Error("timeout while waiting for execution")


### PR DESCRIPTION
- Add new result policies.
- Move policies to it's own file.
- Change default concurrencylimit policy to `FailureOnRejectedPolicy`