### PR TITLE
Fix custom runner sample in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -271,7 +271,7 @@ type Config struct {
 
 // New is like NewFailerMiddleware but will not wrap any other runner, is standalone.
 func New(cfg Config) goresilience.Runner {
-    return NewFailerMiddleware(cfg)(nil)
+    return NewMiddleware(cfg)(nil)
 }
 
 // NewMiddleware returns a new middleware that will wrap runners and will fail
@@ -290,7 +290,7 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
             }
 
             // Run using the the chain.
-            next = runnerutils.Sanitize(next)
+            next = goresilience.Sanitize(next)
             return next.Run(ctx, f)
         })
     }


### PR DESCRIPTION
Hello @slok , first of all, thanks for this great library. I was testing the custom runner that is present in the README and I found it is crashing if the runner is not sanitized before returning the runner func.

I also moved the called times below the check or it will always fail having an attempt remaining :)

Feel free to merge or drop this PR as I've just started to take a look to this repository.

Thanks!