### PR TITLE
Add queued as a measure for the concurrencylimit Limiters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## 0.x.x / 2019-xx-xx
+
+* Pass as additional measuring data the queued time to the concurrencylimit limiters. 
+* Add metrics of the number of executing funcs on concurrencylimit.
+* Add metrics of queued time on concurrencylimit.
+
 ## 0.2.0 / 2019-03-02
 
 * Add Adaptive LIFO with CoDel executor to concurrencylimit.

--- a/concurrencylimit/concurrencylimit.go
+++ b/concurrencylimit/concurrencylimit.go
@@ -79,12 +79,11 @@ func (c *concurrencylimit) Run(ctx context.Context, f goresilience.Func) error {
 	metricsRecorder.SetConcurrencyLimitInflightExecutions(currentInflights)
 
 	var queuedDuration time.Duration // The time in queue.
-	var executing int                // The current executing number of funcs.
 	err := c.cfg.Executor.Execute(func() error {
 		// At this point we are being executed, this means we have been dequeued.
 		queuedDuration = time.Since(start)
 		metricsRecorder.ObserveConcurrencyLimitQueuedTime(start)
-		executing = c.executing.Inc()
+		executing := c.executing.Inc()
 		metricsRecorder.SetConcurrencyLimitExecutingExecutions(executing)
 		defer func() {
 			executing = c.executing.Dec()

--- a/concurrencylimit/concurrencylimit.go
+++ b/concurrencylimit/concurrencylimit.go
@@ -65,6 +65,7 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
 type concurrencylimit struct {
 	runner    goresilience.Runner
 	inflights atomicCounter
+	executing atomicCounter
 	cfg       Config
 }
 
@@ -73,11 +74,24 @@ func (c *concurrencylimit) Run(ctx context.Context, f goresilience.Func) error {
 
 	metricsRecorder, _ := metrics.RecorderFromContext(ctx)
 
-	// Submit the job
+	// Submit the job.
 	currentInflights := c.inflights.Inc()
 	metricsRecorder.SetConcurrencyLimitInflightExecutions(currentInflights)
 
+	var queuedDuration time.Duration // The time in queue.
+	var executing int                // The current executing number of funcs.
 	err := c.cfg.Executor.Execute(func() error {
+		// At this point we are being executed, this means we have been dequeued.
+		queuedDuration = time.Since(start)
+		metricsRecorder.ObserveConcurrencyLimitQueuedTime(start)
+		executing = c.executing.Inc()
+		metricsRecorder.SetConcurrencyLimitExecutingExecutions(executing)
+		defer func() {
+			executing = c.executing.Dec()
+			metricsRecorder.SetConcurrencyLimitExecutingExecutions(executing)
+		}()
+
+		// Execute the logic.
 		return c.runner.Run(ctx, f)
 	})
 
@@ -87,8 +101,12 @@ func (c *concurrencylimit) Run(ctx context.Context, f goresilience.Func) error {
 	// Measure to feed the algorithm.
 	result := c.cfg.ExecutionResultPolicy(ctx, err)
 	metricsRecorder.IncConcurrencyLimitResult(string(result))
+	// If the result is an ignore then we don't measure nor set a new limit.
+	if result == limit.ResultIgnore {
+		return err
+	}
 
-	limit := c.cfg.Limiter.MeasureSample(start, currentInflights, result)
+	limit := c.cfg.Limiter.MeasureSample(start, queuedDuration, currentInflights, result)
 	metricsRecorder.SetConcurrencyLimitLimiterLimit(limit)
 
 	// Update the congestion window based on the new algorithm results.

--- a/concurrencylimit/concurrencylimit_test.go
+++ b/concurrencylimit/concurrencylimit_test.go
@@ -32,7 +32,7 @@ func TestConcurrencyLimit(t *testing.T) {
 				me.On("Execute", mock.Anything).Once().Return(nil)
 
 				// Expect measuring the sample after the execution.
-				ml.On("MeasureSample", mock.Anything, 0, limit.ResultSuccess).Once().Return(measuredLimit)
+				ml.On("MeasureSample", mock.Anything, mock.Anything, 0, limit.ResultSuccess).Once().Return(measuredLimit)
 
 				// Expect setting the limit after measuring with the limiter.
 				me.On("SetWorkerQuantity", measuredLimit)

--- a/concurrencylimit/limit/aimd.go
+++ b/concurrencylimit/limit/aimd.go
@@ -13,7 +13,9 @@ type AIMDConfig struct {
 	// and when reached to this threshold it will change the mode and increase slowly.
 	// If set to 0 then slow start will be disabled.
 	SlowStartThreshold int
-	// RTTTimeout is the rtt is greater than this value it will be measured as a failure.
+	// RTTTimeout is the rtt is greater than this value it will be measured as a failure. This is an important setting
+	// that depedns a lot on the application, by default will be 2s but your app could need a greater timeout or
+	// lesser one.
 	RTTTimeout time.Duration
 	// BackoffRatio is the ratio used to decrease the limit when a failure occurs.
 	// this will be the way is used: new limit = current limit * backoffRatio.
@@ -60,7 +62,7 @@ type aimd struct {
 }
 
 // MeasureSample satisfies Algorithm interface.
-func (a *aimd) MeasureSample(startTime time.Time, inflight int, result Result) int {
+func (a *aimd) MeasureSample(startTime time.Time, _ time.Duration, inflight int, result Result) int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/concurrencylimit/limit/aimd_test.go
+++ b/concurrencylimit/limit/aimd_test.go
@@ -33,7 +33,7 @@ func TestAIMD(t *testing.T) {
 			},
 			measuref: func(alg limit.Limiter) {
 				for i := 0; i < 5; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 30, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 30, limit.ResultSuccess)
 				}
 			},
 			expLimit: 6,
@@ -46,7 +46,7 @@ func TestAIMD(t *testing.T) {
 			},
 			measuref: func(alg limit.Limiter) {
 				for i := 0; i < 5; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 1, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 1, limit.ResultSuccess)
 				}
 			},
 			expLimit: 1,
@@ -59,7 +59,7 @@ func TestAIMD(t *testing.T) {
 			},
 			measuref: func(alg limit.Limiter) {
 				for i := 0; i < 20; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 30, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 30, limit.ResultSuccess)
 				}
 			},
 			expLimit: 7,
@@ -74,11 +74,11 @@ func TestAIMD(t *testing.T) {
 			measuref: func(alg limit.Limiter) {
 				// Start with a high input. (This will set us on a limit of 50)
 				for i := 0; i < 1000; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 3000, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 3000, limit.ResultSuccess)
 				}
 
 				// Fail and make decrease.
-				alg.MeasureSample(now.Add(-10*time.Millisecond), 3000, limit.ResultFailure)
+				alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 3000, limit.ResultFailure)
 			},
 			expLimit: 30,
 		},
@@ -93,15 +93,14 @@ func TestAIMD(t *testing.T) {
 			measuref: func(alg limit.Limiter) {
 				// Start with a high input. (This will set us on a limit of 50)
 				for i := 0; i < 1000; i++ {
-					alg.MeasureSample(now.Add(-100*time.Millisecond), 3000, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-100*time.Millisecond), 0, 3000, limit.ResultSuccess)
 				}
 
 				// Fail and make decrease.
-				alg.MeasureSample(now.Add(-1*time.Second), 3000, limit.ResultSuccess)
+				alg.MeasureSample(now.Add(-1*time.Second), 0, 3000, limit.ResultSuccess)
 			},
 			expLimit: 30,
 		},
-
 		{
 			name: "If we decrease to 0, we should stop on the minimum limit.",
 			cfg: limit.AIMDConfig{
@@ -112,12 +111,12 @@ func TestAIMD(t *testing.T) {
 			measuref: func(alg limit.Limiter) {
 				// Start with a high input. (This will set us on a limit of 50)
 				for i := 0; i < 1000; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 3000, limit.ResultSuccess)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 3000, limit.ResultSuccess)
 				}
 
 				// Fail and make decrease to the minimum.
 				for i := 0; i < 1000; i++ {
-					alg.MeasureSample(now.Add(-10*time.Millisecond), 3000, limit.ResultFailure)
+					alg.MeasureSample(now.Add(-10*time.Millisecond), 0, 3000, limit.ResultFailure)
 				}
 			},
 			expLimit: 3,

--- a/concurrencylimit/limit/limiter.go
+++ b/concurrencylimit/limit/limiter.go
@@ -24,7 +24,7 @@ type Limiter interface {
 	// MeasureSample will measure the sample of an execution. This data will be used
 	// by the algorithm to know what should be the limit.
 	// It also returns the current limit after measuring the samples.
-	MeasureSample(startTime time.Time, inflight int, result Result) int
+	MeasureSample(startTime time.Time, queuedDuration time.Duration, inflight int, result Result) int
 
 	// Gets the current limit.
 	GetLimit() int

--- a/concurrencylimit/limit/static.go
+++ b/concurrencylimit/limit/static.go
@@ -19,7 +19,7 @@ func NewStatic(limit int) Limiter {
 }
 
 // MeasureSample satisfies Algorithm interface.
-func (s *static) MeasureSample(_ time.Time, _ int, _ Result) int {
+func (s *static) MeasureSample(_ time.Time, _ time.Duration, _ int, _ Result) int {
 	return s.GetLimit()
 }
 

--- a/internal/mocks/concurrencylimit/limit/Limiter.go
+++ b/internal/mocks/concurrencylimit/limit/Limiter.go
@@ -25,13 +25,13 @@ func (_m *Limiter) GetLimit() int {
 	return r0
 }
 
-// MeasureSample provides a mock function with given fields: startTime, inflight, result
-func (_m *Limiter) MeasureSample(startTime time.Time, inflight int, result limit.Result) int {
-	ret := _m.Called(startTime, inflight, result)
+// MeasureSample provides a mock function with given fields: startTime, queuedDuration, inflight, result
+func (_m *Limiter) MeasureSample(startTime time.Time, queuedDuration time.Duration, inflight int, result limit.Result) int {
+	ret := _m.Called(startTime, queuedDuration, inflight, result)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(time.Time, int, limit.Result) int); ok {
-		r0 = rf(startTime, inflight, result)
+	if rf, ok := ret.Get(0).(func(time.Time, time.Duration, int, limit.Result) int); ok {
+		r0 = rf(startTime, queuedDuration, inflight, result)
 	} else {
 		r0 = ret.Get(0).(int)
 	}

--- a/metrics/dummy.go
+++ b/metrics/dummy.go
@@ -17,5 +17,7 @@ func (dummy) IncBulkheadTimeout()                                   {}
 func (dummy) IncCircuitbreakerState(state string)                   {}
 func (dummy) IncChaosInjectedFailure(kind string)                   {}
 func (dummy) SetConcurrencyLimitInflightExecutions(q int)           {}
+func (dummy) SetConcurrencyLimitExecutingExecutions(q int)          {}
 func (dummy) IncConcurrencyLimitResult(result string)               {}
 func (dummy) SetConcurrencyLimitLimiterLimit(limit int)             {}
+func (dummy) ObserveConcurrencyLimitQueuedTime(start time.Time)     {}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -28,11 +28,11 @@ type Recorder interface {
 	SetConcurrencyLimitInflightExecutions(q int)
 	// SetConcurrencyLimitExecutingExecutions sets the number of executions at a given moment.
 	SetConcurrencyLimitExecutingExecutions(q int)
-	// IncConcurrencyLimitResult increments the results obtained by the executions after aplying the
+	// IncConcurrencyLimitResult increments the results obtained by the executions after applying the
 	// limiter result policy.
 	IncConcurrencyLimitResult(result string)
 	// SetConcurrencyLimitLimiterLimit sets the current limit the limiter algorithm has calculated.
 	SetConcurrencyLimitLimiterLimit(limit int)
-	// ObserveCommandExecution will measure the execution of the runner chain.
+	// ObserveConcurrencyLimitQueuedTime will measure the duration of a function waiting on a queue until it's executed.
 	ObserveConcurrencyLimitQueuedTime(start time.Time)
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,12 +24,15 @@ type Recorder interface {
 	IncCircuitbreakerState(state string)
 	// IncChaosInjectedFailure increments the number of times injected failure.
 	IncChaosInjectedFailure(kind string)
-	// SetConcurrencyLimitInflightExecutions sets the number of executions at a given moment
-	// executing and queued for execution.
+	// SetConcurrencyLimitInflightExecutions sets the number of queued and executions at a given moment.
 	SetConcurrencyLimitInflightExecutions(q int)
-	// IncConcurrencyLimitResult increments the results obtained by the excutions after aplying the
+	// SetConcurrencyLimitExecutingExecutions sets the number of executions at a given moment.
+	SetConcurrencyLimitExecutingExecutions(q int)
+	// IncConcurrencyLimitResult increments the results obtained by the executions after aplying the
 	// limiter result policy.
 	IncConcurrencyLimitResult(result string)
 	// SetConcurrencyLimitLimiterLimit sets the current limit the limiter algorithm has calculated.
 	SetConcurrencyLimitLimiterLimit(limit int)
+	// ObserveCommandExecution will measure the execution of the runner chain.
+	ObserveConcurrencyLimitQueuedTime(start time.Time)
 }


### PR DESCRIPTION
This PR adds measures about execution and queued duration on concurrency limit:

- Measure as metric the queued duration of the queued time on concurrency limit Runner.
- Measure as metric the number of executing funcs (with the inflights we can get also the number of queued).
- Now the concurrencylimit Limiters can use the queued time as a metrics in order to calculate the new limits.