### PR TITLE
Timeout: Release context associated resources to avoid memory leaks 

### DIFF
--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -53,7 +53,9 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
 			// Set a timeout to the command using the context.
 			// Should we cancel the context if finished...? I guess not, it could continue
 			// the middleware chain.
-			ctx, _ = context.WithTimeout(ctx, cfg.Timeout)
+			ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+
+			defer cancel()
 
 			// Run the command
 			errc := make(chan error)


### PR DESCRIPTION
The linter was throwing a warning:

**timeout/timeout.go:56:9**: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)
```
ctx, _ = context.WithTimeout(ctx, cfg.Timeout)
```

I changed it so deferred cancel gets executed as soon as the operations running in this context complete,  releasing all associated resources.

