### PR TITLE
Checking error rate should use ErrorPercentThresholdToOpen instead of MinimumRequestToOpen

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -185,7 +185,7 @@ func (c *circuitbreaker) postDecideState(metricsRec metrics.Recorder) {
 		}
 	case stateClosed:
 		// Check if we need to go to open state. If we bypassed the thresholds trip the circuit.
-		if c.recorder.totalRequests() >= float64(c.cfg.MinimumRequestToOpen) && c.recorder.errorRate() >= float64(c.cfg.MinimumRequestToOpen)/100 {
+		if c.recorder.totalRequests() >= float64(c.cfg.MinimumRequestToOpen) && c.recorder.errorRate() >= float64(c.cfg.ErrorPercentThresholdToOpen)/100 {
 			c.moveState(stateOpen, metricsRec)
 		}
 	}


### PR DESCRIPTION
Hi @slok, i think i found a bug in the circuit breaker part so that `ErrorPercentThresholdToOpen` configuration value was ignored.
When checking error rate, it should use `ErrorPercentThresholdToOpen` instead of `MinimumRequestToOpen`.