### PR TITLE
Make timeout context cancelable

### DIFF
--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -53,6 +53,19 @@ func TestTimeout(t *testing.T) {
 			},
 			expErr: grerrors.ErrTimeout,
 		},
+		{
+			name: "A command that has been cancelled should not continue and don't let the function panic.",
+			cfg: timeout.Config{
+				Timeout: 1,
+				Cancel: true,
+			},
+			f: func(ctx context.Context) error {
+				time.Sleep(1 * time.Millisecond)
+				panic("this should not happen")
+				return errors.New("this will never be returned")
+			},
+			expErr: grerrors.ErrTimeout,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hey,

I've read the comment on context cancelling in timeout executions. I though it would be a good idea to make this configurable. I've added a bool config field, which does not affect the default behavior.

Cheers