### PR TITLE
export context setter for recorder

### DIFF
--- a/metrics/runner.go
+++ b/metrics/runner.go
@@ -28,7 +28,8 @@ func RecorderFromContext(ctx context.Context) (recorder Recorder, ok bool) {
 	return rec, true
 }
 
-func setRecorderOnContext(ctx context.Context, r Recorder) context.Context {
+// SetRecorderOnContext will set a metrics recorder to the context.
+func SetRecorderOnContext(ctx context.Context, r Recorder) context.Context {
 	return context.WithValue(ctx, ctxRecorderKey, r)
 }
 
@@ -50,7 +51,7 @@ func NewMiddleware(id string, rec Recorder) goresilience.Middleware {
 			// Set the recorder.
 			// WARNING: This could have a performance impact due to the usage of reflect package
 			// by the context. Measure if this has a big impact.
-			ctx = setRecorderOnContext(ctx, rec)
+			ctx = SetRecorderOnContext(ctx, rec)
 
 			next = goresilience.SanitizeRunner(next)
 			err = next.Run(ctx, f)


### PR DESCRIPTION
I've exported the context setter for recorder.
Every runner in this library, that exposes metrics, accesses the `metrics`' context key. The function setting the recorder to the context, however, is unexported and can only be used by the `metrics`'s package middleware.
By exporting it, anybody can write their own metrics middleware, while remaining all other runners metrics reporting to be compatible.