### PR TITLE
Preventing goroutine leaks

### DIFF
--- a/bulkhead/bulkhead.go
+++ b/bulkhead/bulkhead.go
@@ -74,7 +74,7 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
 func (b bulkhead) Run(ctx context.Context, f goresilience.Func) error {
 	metricsRecorder, _ := metrics.RecorderFromContext(ctx)
 
-	resC := make(chan error) // The result channel.
+	resC := make(chan error, 1) // The result channel.
 	job := func() {
 		metricsRecorder.IncBulkheadProcessed()
 		resC <- b.runner.Run(ctx, f)

--- a/concurrencylimit/execute/fifo.go
+++ b/concurrencylimit/execute/fifo.go
@@ -42,7 +42,7 @@ type fifo struct {
 
 // Execute satisfies Executor interface.
 func (f *fifo) Execute(_ context.Context, fn func() error) error {
-	result := make(chan error)
+	result := make(chan error, 1)
 	job := func() {
 		result <- fn()
 	}

--- a/concurrencylimit/execute/lifo.go
+++ b/concurrencylimit/execute/lifo.go
@@ -54,7 +54,7 @@ func (l *lifo) Execute(_ context.Context, f func() error) error {
 	// to be processed.
 	dequeuedJob := make(chan struct{})
 	canceledJob := make(chan struct{})
-	res := make(chan error)
+	res := make(chan error, 1)
 	job := func() {
 		// Send the signal the job has been dequeued.
 		close(dequeuedJob)

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -60,7 +60,7 @@ func NewMiddleware(cfg Config) goresilience.Middleware {
 			}
 
 			// Run the command
-			errc := make(chan error)
+			errc := make(chan error, 1)
 			go func() {
 				errc <- next.Run(ctx, f)
 			}()


### PR DESCRIPTION
When job execution times out, the errorc channel is never emptied.

Because of this, the goroutine never finishes.